### PR TITLE
Fixed Columns Sizing Issue

### DIFF
--- a/src/main/frontend/src/features/items/components/custom_cells/TypeEditCell.tsx
+++ b/src/main/frontend/src/features/items/components/custom_cells/TypeEditCell.tsx
@@ -23,8 +23,17 @@ const TypeEditCell = ({
 
   const onBlur = async () => {
     if (!isCancelled) {
+      const columnId = parseInt(id.replace(/.*?(\d+)$/, "$1"));
+      const oldItemAttribute = row.original.itemAttributes.find(
+        (itemAttribute) => itemAttribute.typeAttribute.id === columnId,
+      );
+
+      if (!oldItemAttribute) {
+        return;
+      }
+
       const itemAttr = {
-        ...row.original.itemAttributes[Number(id.charAt(id.length - 1))],
+        ...oldItemAttribute,
         value: value,
       };
 

--- a/src/main/frontend/src/features/items/data/useTableData.tsx
+++ b/src/main/frontend/src/features/items/data/useTableData.tsx
@@ -10,12 +10,12 @@ import ActionButtons from "../components/custom_cells/ActionButtons";
 import TypeCell from "../components/custom_cells/TypeCell";
 import ImageCell from "@components/custom_cell_renderers/ImageCell";
 import React from "react";
-import { TypeAttribute } from "@schema/Types";
 import TypeEditCell from "@item/components/custom_cells/TypeEditCell";
+import { ZodItemType } from "@schema/General";
 
 const columnHelper = createColumnHelper<Item>();
 
-export const useTableData = (itemData: Item[], filter: TypeAttribute) => {
+export const useTableData = (itemData: Item[], filter: ZodItemType) => {
   const previousColumnRef = useRef<ColumnDef<Item, any>[]>([]);
 
   const columns = useMemo(() => {
@@ -107,7 +107,7 @@ export const useTableData = (itemData: Item[], filter: TypeAttribute) => {
         return columnHelper.accessor(
           (row) => row.itemAttributes[index]?.value || "",
           {
-            id: `${itemAttribute.typeAttribute.columnTitle}-${index}`,
+            id: `typeAttribute-${itemAttribute.typeAttribute.id}`,
             header: () => <div>{itemAttribute.typeAttribute.columnTitle}</div>,
             cell: TypeEditCell,
             minSize: 200,

--- a/src/main/java/dev/adamico/cit/Filtering/ItemSpecification.java
+++ b/src/main/java/dev/adamico/cit/Filtering/ItemSpecification.java
@@ -31,7 +31,7 @@ public class ItemSpecification{
                 } else {
                     predicate = criteriaBuilder.and(predicate,
                                 criteriaBuilder.like(criteriaBuilder.lower(root.join("itemAttributes").get("value")), "%" + value.toLowerCase() + "%"),
-                                criteriaBuilder.like(criteriaBuilder.lower(root.join("itemAttributes").join("typeAttribute").get("columnTitle")), "%" + key.substring(0, key.length() - 2).toLowerCase() + "%"));
+                                criteriaBuilder.equal(root.join("itemAttributes").join("typeAttribute").get("id"), Integer.parseInt(key.replaceAll(".*?(\\d+)$", "$1"))));
                 }
             }
 


### PR DESCRIPTION
The column headers were using the coulmnTitle as part of the string, this was causing an issue with assigning the correct CSS classes to the specific headers. i.e if a user made the column header contain a special character, it wouldn't assign the classes correctly.